### PR TITLE
Bug results returns negative seats won

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -362,7 +362,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             config=config,
             election_dict=event["election"],
         )
-    except Exception as e:
+    except ValueError as e:
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},


### PR DESCRIPTION
I tried adding another try/except block to catch the error in the main lambda function, but I confirmed that if -1 is a key in the `Counter` object, the simulation function will catch it and raise a ValueError.