### PR TITLE
update votekit requirements

### DIFF
--- a/lambda/requirements.dev.txt
+++ b/lambda/requirements.dev.txt
@@ -2,4 +2,4 @@ fastapi>=0.111,<0.112
 uvicorn[standard]>=0.30,<0.31
 jsonschema==4.25.1
 boto3==1.40.40
-git+https://github.com/mggg/votekit.git@3.3.0
+votekit==3.3.0

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -3,4 +3,4 @@
 # requests==2.32.3
 jsonschema==4.25.1
 boto3==1.40.40
-git+https://github.com/mggg/votekit.git@3.3.0
+votekit==3.3.0


### PR DESCRIPTION
Pin votekit requirement to 3.3.0, now that it is a main release.