### PR TITLE
Better error text and additional CS Validation

### DIFF
--- a/app/src/lib/utils/validateCsBehavior.ts
+++ b/app/src/lib/utils/validateCsBehavior.ts
@@ -18,9 +18,17 @@ export const validateCsBehavior = (
 	// Check if bloc names match slate names
 	const slateNames = slates.map((slate) => slate.name).sort();
 	const blocNames = blocs.map((bloc) => bloc.name).sort();
+	const blocsAreEqual = blocs.every(
+		(bloc) => bloc.population * bloc.turnout === blocs[0].population * blocs[0].turnout
+	);
 	if (JSON.stringify(slateNames) !== JSON.stringify(blocNames)) {
 		errors.push(
 			'For Cambridge voters, the voter blocs must have the same names as the slates of candidates.'
+		);
+	}
+	if (blocsAreEqual) {
+		errors.push(
+			'For Cambridge voters, the voter blocs cannot have the exact same number of voters.'
 		);
 	}
 


### PR DESCRIPTION
CS simulations failed silently when the blocs have equal proportions. This is currently a requirement on the backend, but it was failing at the trial level and not propagating the error up to the actual error logging. 